### PR TITLE
Improve postcode.php

### DIFF
--- a/postcode.php
+++ b/postcode.php
@@ -86,7 +86,7 @@ if (!strstr($row['countygss'], "99999999")) {
 
 	if (strlen($row['electoraldistrict']) == 0) {
 		
-		$mapit = json_decode(file_get_contents("http://mapit.mysociety.org/postcode/". urlencode($postcode) .".json"));
+		$mapit = json_decode(file_get_contents("http://mapit.mysociety.org/postcode/". urlencode($updatepostcode) .".json"));
 					
 		foreach ($mapit->areas as $area) {
 			if ($area->type_name == "County council ward") {
@@ -126,7 +126,7 @@ if (strlen($constituencycode) == 3) {
 
 if (strlen($row['parish'] == 0)) {
 
-	$mapit = json_decode(file_get_contents("http://mapit.mysociety.org/postcode/". $postcode .".json"));
+	$mapit = json_decode(file_get_contents("http://mapit.mysociety.org/postcode/". urlencode($updatepostcode) .".json"));
 
 	foreach ($mapit->areas as $area) {
 		if ($area->type_name == "Civil Parish") {

--- a/postcode.php
+++ b/postcode.php
@@ -125,7 +125,7 @@ if (strlen($constituencycode) == 3) {
 	$constituencyuri = "http://data.ordnancesurvey.co.uk/doc/7". str_pad($constituencycode, 15, "0", STR_PAD_LEFT);
 }
 
-if (strlen($row['parish'] == 0)) {
+if (strlen($row['parishgss'] == 0)) {
 
 	if (!$mapit) {
 		$mapit = json_decode(file_get_contents("http://mapit.mysociety.org/postcode/". urlencode($updatepostcode) .".json"));

--- a/postcode.php
+++ b/postcode.php
@@ -20,6 +20,7 @@ if ($_GET['postcode']) {
 		} else {
 			header("Location: http://www.uk-postcodes.com/postcode/".strtoupper($postcode));
 		}
+		exit;
 	}
 
 	if (strstr($postcode, " ")) {
@@ -30,6 +31,7 @@ if ($_GET['postcode']) {
 		} else {
 			header("Location: http://www.uk-postcodes.com/postcode/".str_replace(" ", "", $postcode));
 		}
+		exit;
 	}
 
 	if (strlen($postcode) == 6) {

--- a/postcode.php
+++ b/postcode.php
@@ -79,6 +79,7 @@ $northing = $row['northing'];
 
 $geohash = file_get_contents("http://geohash.org?q=".$lat.",".$lng."&format=url");
 
+$mapit = null;
 if (!strstr($row['countygss'], "99999999")) {
 
 	$countytitle = $row['countyname'];
@@ -126,7 +127,9 @@ if (strlen($constituencycode) == 3) {
 
 if (strlen($row['parish'] == 0)) {
 
-	$mapit = json_decode(file_get_contents("http://mapit.mysociety.org/postcode/". urlencode($updatepostcode) .".json"));
+	if (!$mapit) {
+		$mapit = json_decode(file_get_contents("http://mapit.mysociety.org/postcode/". urlencode($updatepostcode) .".json"));
+	}
 
 	foreach ($mapit->areas as $area) {
 		if ($area->type_name == "Civil Parish") {

--- a/postcode.php
+++ b/postcode.php
@@ -97,7 +97,7 @@ if (!strstr($row['countygss'], "99999999")) {
 			}
 		}
 	
-		mysql_query("UPDATE postcodes SET electoraldistrict = '$edistrict[code]' WHERE postcode = '$updatepostcode'");	
+		//mysql_query("UPDATE postcodes SET electoraldistrict = '$edistrict[code]' WHERE postcode = '$updatepostcode'");
 	}
 
 }


### PR DESCRIPTION
Hi,

For any two-tier council, postcode.php is making two identical requests to mapit. It is also making its mapit requests invalidly, either by not escaping properly postcodes with a space, or by not using a postcode at all (if from a lat/lon request). It doesn't check the database results for parishes correctly, and doesn't exit when doing a redirect, leading to mapit calls being made which are then made again after the redirect takes place.

This pull request should fix all the above.
